### PR TITLE
Add consecutive special questions prevention

### DIFF
--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -2284,15 +2284,6 @@
   }
 }
 
-@keyframes specialPlaylistPulse {
-  0%, 100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.05);
-  }
-}
-
 /* Version B Special Question Playlist Display */
 .special-playlist-display {
   position: fixed;


### PR DESCRIPTION
This PR adds consecutive special questions prevention to Version B.

## Changes
- Modified special question selection algorithm to prevent back-to-back special questions
- Added validation to ensure no consecutive numbers (e.g., 3,4 or 5,6)
- Added safety checks and fallback logic
- Removed debug text from top right corner
- Enhanced logging for special question selection process

## Features
- 50% chance for 1 or 2 special questions per session
- No consecutive special questions (prevents 3,4 or 5,6)
- Random selection from questions 2-7
- Cross-playlist songs for special questions
- 50-100 point scoring for special questions
- Transition screens for each special question
- Clean UI without debug text