### PR TITLE
Add lifeline attention animation for Version B

### DIFF
--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -2284,6 +2284,37 @@
   }
 }
 
+/* Version B Lifeline Attention Animation */
+.boosters-section.lifeline-attention {
+  animation: lifelineAttentionPulse 0.5s ease-in-out 4;
+  transform-origin: center;
+}
+
+.boosters-section.lifeline-attention .booster-icon:not(.depleted) {
+  animation: lifelineIconGlow 0.5s ease-in-out 4;
+  box-shadow: 0 0 20px rgba(78, 205, 196, 0.8), 0 0 40px rgba(78, 205, 196, 0.6);
+}
+
+@keyframes lifelineAttentionPulse {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+}
+
+@keyframes lifelineIconGlow {
+  0%, 100% {
+    box-shadow: 0 0 20px rgba(78, 205, 196, 0.8), 0 0 40px rgba(78, 205, 196, 0.6);
+    border-color: #4ecdc4;
+  }
+  50% {
+    box-shadow: 0 0 30px rgba(78, 205, 196, 1), 0 0 60px rgba(78, 205, 196, 0.8), 0 0 80px rgba(78, 205, 196, 0.6);
+    border-color: #ffffff;
+  }
+}
+
 /* Version B Special Question Playlist Display */
 .special-playlist-display {
   position: fixed;

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -126,6 +126,10 @@ const Game = () => {
   // Version B Special Question tracking
   const [specialQuestionNumbers, setSpecialQuestionNumbers] = useState<number[]>([])
   const [specialQuestionPlaylist, setSpecialQuestionPlaylist] = useState<string | null>(null)
+  
+  // Version B Lifeline attention animation
+  const [showLifelineAttention, setShowLifelineAttention] = useState(false)
+  const lifelineAttentionTimerRef = useRef<NodeJS.Timeout | null>(null)
   // 2010s playlist songs with curated alternatives
   const songs2010s: Song[] = [
     { 
@@ -1228,6 +1232,47 @@ const Game = () => {
     }
   }
 
+  // Helper function to check if any lifelines are still available
+  const hasAvailableLifelines = () => {
+    return !lifelinesUsed.doublePoints || !lifelinesUsed.skip || !lifelinesUsed.letterReveal
+  }
+
+  // Helper function to start lifeline attention animation
+  const startLifelineAttentionAnimation = () => {
+    if (version !== 'Version B' || !hasAvailableLifelines()) {
+      return
+    }
+
+    // Clear any existing timer
+    if (lifelineAttentionTimerRef.current) {
+      clearTimeout(lifelineAttentionTimerRef.current)
+    }
+
+    // Start animation after 5 seconds
+    lifelineAttentionTimerRef.current = setTimeout(() => {
+      setShowLifelineAttention(true)
+      
+      // Stop animation after 2 seconds
+      setTimeout(() => {
+        setShowLifelineAttention(false)
+        
+        // Schedule next animation if still no answer and lifelines available
+        if (version === 'Version B' && hasAvailableLifelines() && !showFeedback) {
+          startLifelineAttentionAnimation()
+        }
+      }, 2000)
+    }, 5000)
+  }
+
+  // Helper function to stop lifeline attention animation
+  const stopLifelineAttentionAnimation = () => {
+    if (lifelineAttentionTimerRef.current) {
+      clearTimeout(lifelineAttentionTimerRef.current)
+      lifelineAttentionTimerRef.current = null
+    }
+    setShowLifelineAttention(false)
+  }
+
   // Helper function that works with specific question number to avoid state timing issues
   const startNewQuestionWithNumber = (questionNum: number) => {
     console.log('🎵 START: Starting question', questionNum, 'for version', version)
@@ -1271,12 +1316,15 @@ const Game = () => {
       audio.onloadedmetadata = null
       audio.onerror = null
       
-      // Complete reset of audio element for all versions (not just Version C)
-      audio.src = ''
-      audio.load()
-    }
-    
-    const question = isSpecialQuestion ? generateSpecialQuizQuestion() : generateQuizQuestion()
+    // Complete reset of audio element for all versions (not just Version C)
+    audio.src = ''
+    audio.load()
+  }
+  
+  // Stop lifeline attention animation when starting new question
+  stopLifelineAttentionAnimation()
+  
+  const question = isSpecialQuestion ? generateSpecialQuizQuestion() : generateQuizQuestion()
     setCurrentQuestion(question)
     setSelectedAnswer(null)
     setShowFeedback(false)
@@ -1835,6 +1883,9 @@ const Game = () => {
 
   // Version B Lifeline handler
   const handleLifelineClick = (lifelineType: 'doublePoints' | 'skip' | 'letterReveal') => {
+    // Stop lifeline attention animation when any lifeline is used
+    stopLifelineAttentionAnimation()
+    
     // Check if lifeline is already used
     if (lifelinesUsed[lifelineType]) {
       return // Do nothing if already used
@@ -2053,6 +2104,9 @@ const Game = () => {
   }
 
   const handleAnswerSelect = (answer: string) => {
+    // Stop lifeline attention animation when question is answered
+    stopLifelineAttentionAnimation()
+    
     if (selectedAnswer) return // Already answered
     
     setSelectedAnswer(answer)
@@ -2233,6 +2287,7 @@ const Game = () => {
     setShowSpecialQuestionTransition(false) // Reset Special Question transition
     setSpecialQuestionNumbers([]) // Reset special question tracking
     setSpecialQuestionPlaylist(null) // Reset special playlist
+    stopLifelineAttentionAnimation() // Stop lifeline attention animation
     setTimerPulse(false)
     setShowScoreConfetti(false)
     if (timerRef.current) {
@@ -2701,7 +2756,13 @@ const Game = () => {
                 <audio
                   ref={audioRef}
                   src={currentQuestion?.song?.file}
-                  onEnded={() => setIsPlaying(false)}
+                  onEnded={() => {
+                    setIsPlaying(false)
+                    // Start lifeline attention animation for Version B after song ends
+                    if (version === 'Version B') {
+                      startLifelineAttentionAnimation()
+                    }
+                  }}
                 />
               </div>
             )}
@@ -2745,7 +2806,7 @@ const Game = () => {
 
             {/* Version B Boosters */}
             {version === 'Version B' && !showFeedback && (
-              <div className="boosters-section">
+              <div className={`boosters-section ${showLifelineAttention ? 'lifeline-attention' : ''}`}>
                 <div className="boosters-header">LIFELINES</div>
                 <div className="boosters-container">
                   <div 


### PR DESCRIPTION
This PR adds a lifeline attention animation system to Version B.

## Changes
- Added pulsing/glow animation to draw attention to lifelines
- Animation starts 5 seconds after song ends and repeats every 5 seconds
- Stops when new question starts, lifeline is used, or question is answered
- Only runs when at least one lifeline is still available
- Includes CSS animations for section pulsing and icon glowing
- Prevents animation during song playback

## Features
- Pulsing/glow animation to draw attention to lifelines
- Starts 5 seconds after song ends
- Repeats every 5 seconds until stopped
- Stops when new question starts, lifeline is used, or question is answered
- Only runs when at least one lifeline is still available
- Prevents animation during song playback

## Animation Effects
- Section pulsing (scale 1.0 → 1.05)
- Icon glowing with teal color
- 4 cycles over 2 seconds
- Smooth transitions and timing