### PR TITLE
Add debug buttons for Special Question types

### DIFF
--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -602,6 +602,56 @@
   box-shadow: 0 8px 25px rgba(255, 0, 0, 0.5);
 }
 
+/* Version B Debug Special Question Buttons */
+.debug-special-buttons {
+  position: fixed;
+  bottom: 6rem;
+  right: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 20;
+}
+
+.debug-special-button {
+  background: rgba(0, 0, 0, 0.7);
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 6px;
+  padding: 0.6rem 1rem;
+  color: #ffffff;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-size: 0.9rem;
+  font-weight: 500;
+  min-width: 100px;
+  text-align: center;
+}
+
+.debug-special-button:hover {
+  background: rgba(0, 0, 0, 0.8);
+  border-color: rgba(255, 255, 255, 0.5);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5);
+}
+
+.time-warp-debug:hover {
+  background: rgba(78, 205, 196, 0.8);
+  border-color: rgba(78, 205, 196, 0.5);
+  box-shadow: 0 6px 20px rgba(78, 205, 196, 0.5);
+}
+
+.slo-mo-debug:hover {
+  background: rgba(255, 107, 107, 0.8);
+  border-color: rgba(255, 107, 107, 0.5);
+  box-shadow: 0 6px 20px rgba(255, 107, 107, 0.5);
+}
+
+.hyperspeed-debug:hover {
+  background: rgba(255, 215, 0, 0.8);
+  border-color: rgba(255, 215, 0, 0.5);
+  box-shadow: 0 6px 20px rgba(255, 215, 0, 0.5);
+}
+
 /* Quiz-specific styles */
 .quiz-options {
   display: flex;
@@ -1104,6 +1154,18 @@
     right: 1rem;
     padding: 0.7rem 1.2rem;
     font-size: 0.9rem;
+  }
+  
+  .debug-special-buttons {
+    bottom: 5rem;
+    right: 1rem;
+    gap: 0.4rem;
+  }
+  
+  .debug-special-button {
+    padding: 0.5rem 0.8rem;
+    font-size: 0.8rem;
+    min-width: 80px;
   }
   
   .final-score {

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -2314,18 +2314,24 @@ const Game = () => {
       if (version === 'Version B' && specialQuestionNumbers.includes(newQuestionNumber)) {
         console.log('🎯 SPECIAL QUESTION: Transition screen triggered for Question', newQuestionNumber)
         
-        // Select special question type before showing transition
-        const randomValue = Math.random()
+        // Use existing special question type if set (from debug buttons), otherwise select randomly
         let specialType: 'time-warp' | 'slo-mo' | 'hyperspeed'
-        if (randomValue < 0.33) {
-          specialType = 'time-warp'
-        } else if (randomValue < 0.66) {
-          specialType = 'slo-mo'
+        if (specialQuestionType) {
+          specialType = specialQuestionType
+          console.log('🎯 DEBUG: Using pre-set special question type:', specialType)
         } else {
-          specialType = 'hyperspeed'
+          // Select special question type randomly
+          const randomValue = Math.random()
+          if (randomValue < 0.33) {
+            specialType = 'time-warp'
+          } else if (randomValue < 0.66) {
+            specialType = 'slo-mo'
+          } else {
+            specialType = 'hyperspeed'
+          }
+          setSpecialQuestionType(specialType)
+          console.log('🎲 RANDOM SELECTION: Math.random() =', randomValue, 'Type selected:', specialType)
         }
-        setSpecialQuestionType(specialType)
-        console.log('🎲 RANDOM SELECTION: Math.random() =', randomValue, 'Type selected:', specialType)
         
         // Show Special Question transition screen
         setShowSpecialQuestionTransition(true)
@@ -2335,6 +2341,9 @@ const Game = () => {
           setShowSpecialQuestionTransition(false)
           setQuestionNumber(newQuestionNumber)
           console.log('🎯 SPECIAL QUESTION: Starting Question', newQuestionNumber, 'with special scoring')
+          
+          // Reset special question type after using it
+          setSpecialQuestionType(null)
           
           // Start new question with proper delay for cleanup
           setTimeout(() => {
@@ -2402,6 +2411,29 @@ const Game = () => {
     // Note: doublePointsTimerRef was removed, no cleanup needed
     
     startNewQuestion()
+  }
+
+  // Debug function to force next question to be a specific special question type
+  const handleDebugSpecialQuestion = (specialType: 'time-warp' | 'slo-mo' | 'hyperspeed') => {
+    console.log('🐛 DEBUG: Forcing next question to be', specialType, 'Special Question')
+    
+    // Set the next question number as a special question
+    const nextQuestionNumber = questionNumber + 1
+    
+    // Add this question to special question numbers
+    setSpecialQuestionNumbers(prev => {
+      const newNumbers = [...prev]
+      if (!newNumbers.includes(nextQuestionNumber)) {
+        newNumbers.push(nextQuestionNumber)
+        newNumbers.sort((a, b) => a - b)
+      }
+      return newNumbers
+    })
+    
+    // Set the special question type
+    setSpecialQuestionType(specialType)
+    
+    console.log('🐛 DEBUG: Next question', nextQuestionNumber, 'will be', specialType, 'Special Question')
   }
 
   const backToPlaylist = () => {
@@ -3343,6 +3375,33 @@ const Game = () => {
           >
             Restart
           </button>
+        )}
+
+        {/* Version B Special Question Debug Buttons */}
+        {version === 'Version B' && !showSpecialQuestionTransition && (
+          <div className="debug-special-buttons">
+            <button 
+              className="debug-special-button time-warp-debug"
+              onClick={() => handleDebugSpecialQuestion('time-warp')}
+              title="Force next question to be Time Warp Special Question"
+            >
+              Time Warp
+            </button>
+            <button 
+              className="debug-special-button slo-mo-debug"
+              onClick={() => handleDebugSpecialQuestion('slo-mo')}
+              title="Force next question to be Slo-Mo Special Question"
+            >
+              Slo-Mo
+            </button>
+            <button 
+              className="debug-special-button hyperspeed-debug"
+              onClick={() => handleDebugSpecialQuestion('hyperspeed')}
+              title="Force next question to be Hyperspeed Special Question"
+            >
+              Hyperspeed
+            </button>
+          </div>
         )}
 
       </div>


### PR DESCRIPTION
## Debug Buttons for Special Question Types

This PR adds three debug buttons to Version B that allow developers to force the next question to be a specific special question type.

### Features Added

- **Time Warp Debug Button**: Forces next question to be Time Warp Special Question
- **Slo-Mo Debug Button**: Forces next question to be Slo-Mo Special Question  
- **Hyperspeed Debug Button**: Forces next question to be Hyperspeed Special Question

### Implementation Details

- Buttons positioned in lower right corner above Restart button
- Color-coded hover effects (teal, red, gold)
- Mobile responsive design
- Proper state management with cleanup after use
- Fixed bug where debug buttons were being overridden by random selection

### Technical Changes

- Added `handleDebugSpecialQuestion()` function
- Updated `nextQuestion()` to respect pre-set special question types
- Added CSS styling for debug buttons and mobile responsiveness
- Proper state reset after special question completion

### Testing

- Debug buttons correctly force the selected special question type
- Transition screens show correct special question type
- Audio playback works at appropriate speeds for each type
- No interference with normal random special question selection