### PR TITLE
Remove debug text showing special question numbers

### DIFF
--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -3884,29 +3884,3 @@
     font-size: 3.5rem !important;
   }
 }
-
-/* Version B Debug Text - Special Question Numbers */
-.debug-special-questions {
-  position: fixed;
-  top: 20px;
-  right: 20px;
-  background: rgba(0, 0, 0, 0.8);
-  color: #ffffff;
-  padding: 8px 12px;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 600;
-  font-family: 'Inter', sans-serif;
-  z-index: 1000;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  backdrop-filter: blur(5px);
-}
-
-@media (max-width: 768px) {
-  .debug-special-questions {
-    top: 15px;
-    right: 15px;
-    font-size: 12px;
-    padding: 6px 10px;
-  }
-}

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -2881,13 +2881,6 @@ const Game = () => {
         </div>
       )}
 
-      {/* Version B Debug Text - Special Question Numbers */}
-      {version === 'Version B' && (
-        <div className="debug-special-questions">
-          Special Questions: {specialQuestionNumbers.length > 0 ? specialQuestionNumbers.join(', ') : 'None'}
-        </div>
-      )}
-
         <main className="game-main" style={{ display: showSpecialQuestionTransition ? 'none' : 'block' }}>
           <div className="quiz-section">
             {!showFeedback && (


### PR DESCRIPTION
## Remove Debug Text for Cleaner UI

This PR removes the debug text from the upper right corner that was displaying which questions would be special questions.

### Changes Made

- **Removed debug text JSX element** from upper right corner
- **Removed CSS styling** for `.debug-special-questions` class
- **Removed mobile responsive styles** for debug text
- **Cleaned up UI** for better player experience

### Impact

- **Cleaner gameplay experience** - players no longer see which questions are special
- **More authentic game flow** - special questions are now truly random surprises
- **Debug buttons remain available** in lower right corner for testing purposes
- **No functional changes** - only UI cleanup

### Technical Details

- Removed conditional JSX rendering of debug text
- Removed all associated CSS rules and media queries
- Maintained all existing functionality
- Debug buttons for testing special question types remain intact

### Testing

- Version B gameplay flows normally without debug text
- Special questions still appear randomly as intended
- Debug buttons still work for testing specific special question types
- No visual artifacts or layout issues