### PR TITLE
Abbreviate Special Question debug button text

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -2436,6 +2436,12 @@ const Game = () => {
       return newNumbers
     })
     
+    // Set the special question type for this question
+    setSpecialQuestionTypes(prev => ({
+      ...prev,
+      [nextQuestionNumber]: specialType
+    }))
+    
     // Set the special question type
     setSpecialQuestionType(specialType)
     
@@ -3405,21 +3411,21 @@ const Game = () => {
               onClick={() => handleDebugSpecialQuestion('time-warp')}
               title="Force next question to be Time Warp Special Question"
             >
-              Time Warp
+              TW
             </button>
             <button 
               className="debug-special-button slo-mo-debug"
               onClick={() => handleDebugSpecialQuestion('slo-mo')}
               title="Force next question to be Slo-Mo Special Question"
             >
-              Slo-Mo
+              SM
             </button>
             <button 
               className="debug-special-button hyperspeed-debug"
               onClick={() => handleDebugSpecialQuestion('hyperspeed')}
               title="Force next question to be Hyperspeed Special Question"
             >
-              Hyperspeed
+              HS
             </button>
           </div>
         )}


### PR DESCRIPTION
## Changes

- Abbreviated Special Question debug button text for better UI:
  - Time Warp → TW
  - Slo-Mo → SM
  - Hyperspeed → HS
- Fixed debug button functionality to properly set special question types
- Maintained full tooltips for clarity

## Testing

- Debug buttons now work correctly and don't break game progression
- Abbreviated text saves space while maintaining functionality
- Tooltips provide full descriptions on hover