### PR TITLE
feat(version-b): Refine time bonus window and timer visual feedback

### DIFF
--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -4198,3 +4198,34 @@
   }
 }
 
+/* Version B Floating Points Animation */
+.floating-points {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 4rem;
+  font-weight: bold;
+  color: #00ff88;
+  text-shadow: 0 0 20px rgba(0, 255, 136, 0.8),
+               0 0 40px rgba(0, 255, 136, 0.6),
+               0 0 60px rgba(0, 255, 136, 0.4);
+  z-index: 1000;
+  pointer-events: none;
+  animation: floatUp 2s ease-out forwards;
+}
+
+@keyframes floatUp {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) translateY(0);
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) translateY(-100px);
+  }
+}
+

--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -4224,6 +4224,17 @@
   text-transform: uppercase;
 }
 
+.floating-points-time-bonus {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #00d4ff;
+  text-shadow: 0 0 15px rgba(0, 212, 255, 0.8),
+               0 0 30px rgba(0, 212, 255, 0.6),
+               0 0 45px rgba(0, 212, 255, 0.4);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
 .floating-points-value {
   font-size: 4rem;
   font-weight: bold;

--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -3138,11 +3138,21 @@
   min-width: 120px;
 }
 
+.timer-value.timer-bonus {
+  background: linear-gradient(135deg, #00ff88, #00d4a0);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: bonusPulse 1.5s ease-in-out infinite;
+}
+
 .timer-value.timer-urgent {
   background: linear-gradient(135deg, #ff6b6b, #ee5a24);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   animation: urgentPulse 1s ease-in-out infinite;
+  transform: scale(1.3);
+  transform-origin: center;
+  transition: transform 0.3s ease-out;
 }
 
 .attempts-counter {
@@ -3165,6 +3175,17 @@
   border-radius: 6px;
   border: 1px solid rgba(255, 255, 255, 0.2);
   font-weight: 500;
+}
+
+@keyframes bonusPulse {
+  0%, 100% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 8px rgba(0, 255, 136, 0.8));
+  }
+  50% {
+    transform: scale(1.05);
+    filter: drop-shadow(0 0 15px rgba(0, 255, 136, 1));
+  }
 }
 
 @keyframes urgentPulse {

--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -4204,15 +4204,33 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  z-index: 1000;
+  pointer-events: none;
+  animation: floatUp 2s ease-out forwards;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.floating-points-special {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #ffd700;
+  text-shadow: 0 0 15px rgba(255, 215, 0, 0.8),
+               0 0 30px rgba(255, 215, 0, 0.6),
+               0 0 45px rgba(255, 215, 0, 0.4);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.floating-points-value {
   font-size: 4rem;
   font-weight: bold;
   color: #00ff88;
   text-shadow: 0 0 20px rgba(0, 255, 136, 0.8),
                0 0 40px rgba(0, 255, 136, 0.6),
                0 0 60px rgba(0, 255, 136, 0.4);
-  z-index: 1000;
-  pointer-events: none;
-  animation: floatUp 2s ease-out forwards;
 }
 
 @keyframes floatUp {

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -3166,19 +3166,19 @@ const Game = () => {
                     className="score-button score-0"
                     onClick={() => handleVersionBScore(0)}
                   >
-                    0 Points
+                    None
                   </button>
                 <button
                   className="score-button score-10"
-                  onClick={() => handleVersionBScore(isDoublePointsActive ? (specialQuestionNumbers.includes(questionNumber) ? 100 : 20) : (specialQuestionNumbers.includes(questionNumber) ? 50 : 10))}
+                  onClick={() => handleVersionBScore(isDoublePointsActive ? (specialQuestionNumbers.includes(questionNumber) ? 40 : 20) : (specialQuestionNumbers.includes(questionNumber) ? 20 : 10))}
                 >
-                  {isDoublePointsActive ? (specialQuestionNumbers.includes(questionNumber) ? '100 Points' : '20 Points') : (specialQuestionNumbers.includes(questionNumber) ? '50 Points' : '10 Points')}
+                  One
                 </button>
                 <button
                   className="score-button score-20"
-                  onClick={() => handleVersionBScore(isDoublePointsActive ? (specialQuestionNumbers.includes(questionNumber) ? 200 : 40) : (specialQuestionNumbers.includes(questionNumber) ? 100 : 20))}
+                  onClick={() => handleVersionBScore(isDoublePointsActive ? (specialQuestionNumbers.includes(questionNumber) ? 80 : 40) : (specialQuestionNumbers.includes(questionNumber) ? 40 : 20))}
                 >
-                  {isDoublePointsActive ? (specialQuestionNumbers.includes(questionNumber) ? '200 Points' : '40 Points') : (specialQuestionNumbers.includes(questionNumber) ? '100 Points' : '20 Points')}
+                  Both
                 </button>
                   {/* No special scoring for question 7 since it's now a special question */}
                 </div>

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -59,6 +59,7 @@ const Game = () => {
   // Version B floating points animation
   const [showFloatingPoints, setShowFloatingPoints] = useState(false)
   const [floatingPointsValue, setFloatingPointsValue] = useState(0)
+  const [isFloatingPointsSpecial, setIsFloatingPointsSpecial] = useState(false)
   const totalQuestions = 7
 
   // Version A specific state
@@ -2029,6 +2030,7 @@ const Game = () => {
       playCorrectAnswerSfx()
       // Trigger floating points animation
       setFloatingPointsValue(points)
+      setIsFloatingPointsSpecial(specialQuestionNumbers.includes(questionNumber))
       setShowFloatingPoints(true)
     }
     
@@ -3210,7 +3212,10 @@ const Game = () => {
             {/* Version B Floating Points Animation */}
             {version === 'Version B' && showFloatingPoints && (
               <div className="floating-points">
-                +{floatingPointsValue}
+                {isFloatingPointsSpecial && (
+                  <div className="floating-points-special">Special Question 2X</div>
+                )}
+                <div className="floating-points-value">+{floatingPointsValue}</div>
               </div>
             )}
             

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -60,6 +60,10 @@ const Game = () => {
   const [showFloatingPoints, setShowFloatingPoints] = useState(false)
   const [floatingPointsValue, setFloatingPointsValue] = useState(0)
   const [isFloatingPointsSpecial, setIsFloatingPointsSpecial] = useState(false)
+  const [isFloatingPointsTimeBonus, setIsFloatingPointsTimeBonus] = useState(false)
+  
+  // Version B time bonus tracking
+  const [questionStartTime, setQuestionStartTime] = useState<number>(0)
   const totalQuestions = 7
 
   // Version A specific state
@@ -1371,6 +1375,8 @@ const Game = () => {
       }
       setVersionBTimeRemaining(20)
       setVersionBTimerRunning(true)
+      // Track question start time for time bonus
+      setQuestionStartTime(Date.now())
     } else if (version === 'Version C') {
       // Version C: Start timer if not already running, or continue if still running
       if (!isTimerRunning && timeRemaining === 30) {
@@ -1992,6 +1998,16 @@ const Game = () => {
 
     setSelectedAnswer('manual_score')
     
+    // Check for time bonus (answered within 7 seconds)
+    const elapsedTime = Date.now() - questionStartTime
+    const hasTimeBonus = points > 0 && elapsedTime <= 7000
+    let finalPoints = points
+    
+    if (hasTimeBonus) {
+      finalPoints = points * 2
+      console.log('⏱️ TIME BONUS: Answered in', (elapsedTime / 1000).toFixed(1), 'seconds! Points doubled from', points, 'to', finalPoints)
+    }
+    
     let artistCorrect = false
     let songCorrect = false
     
@@ -2020,17 +2036,18 @@ const Game = () => {
     
     setArtistCorrect(artistCorrect)
     setSongCorrect(songCorrect)
-    setIsCorrect(points > 0) // Player gets credit for positive points only
-    setPointsEarned(points)
+    setIsCorrect(finalPoints > 0) // Player gets credit for positive points only
+    setPointsEarned(finalPoints)
     
     // Record base correctness for percentage calculation (Version B)
     setQuestionsCorrectness(prev => [...prev, { artistCorrect, songCorrect }])
     
-    if (points > 0) {
+    if (finalPoints > 0) {
       playCorrectAnswerSfx()
       // Trigger floating points animation
-      setFloatingPointsValue(points)
+      setFloatingPointsValue(finalPoints)
       setIsFloatingPointsSpecial(specialQuestionNumbers.includes(questionNumber))
+      setIsFloatingPointsTimeBonus(hasTimeBonus)
       setShowFloatingPoints(true)
     }
     
@@ -3214,6 +3231,9 @@ const Game = () => {
               <div className="floating-points">
                 {isFloatingPointsSpecial && (
                   <div className="floating-points-special">Special Question 2X</div>
+                )}
+                {isFloatingPointsTimeBonus && (
+                  <div className="floating-points-time-bonus">Time Bonus 2X</div>
                 )}
                 <div className="floating-points-value">+{floatingPointsValue}</div>
               </div>

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -70,6 +70,10 @@ const Game = () => {
   // Version C specific state
   const [timeRemaining, setTimeRemaining] = useState(30)
   const [isTimerRunning, setIsTimerRunning] = useState(false)
+  
+  // Version B per-question timer state
+  const [versionBTimeRemaining, setVersionBTimeRemaining] = useState(20)
+  const [versionBTimerRunning, setVersionBTimerRunning] = useState(false)
   const [allAttemptedSongs, setAllAttemptedSongs] = useState<Array<{
     song: any,
     pointsEarned: number,
@@ -86,6 +90,8 @@ const Game = () => {
   const [showScoreConfetti, setShowScoreConfetti] = useState(false) // Track confetti animation
   
   const timerRef = useRef<NodeJS.Timeout | null>(null)
+  // Separate timer ref for Version B per-question timer
+  const versionBTimerRef = useRef<NodeJS.Timeout | null>(null)
   
   // Note: Song tracking is now handled by persistent localStorage via songTracker utility
   
@@ -1353,7 +1359,13 @@ const Game = () => {
         }, buzzInDelay)
       }
     } else if (version === 'Version B') {
-      // Version B has no opponent mechanics
+      // Version B: start per-question 30s timer
+      if (versionBTimerRef.current) {
+        clearTimeout(versionBTimerRef.current)
+        versionBTimerRef.current = null
+      }
+      setVersionBTimeRemaining(20)
+      setVersionBTimerRunning(true)
     } else if (version === 'Version C') {
       // Version C: Start timer if not already running, or continue if still running
       if (!isTimerRunning && timeRemaining === 30) {
@@ -1693,6 +1705,32 @@ const Game = () => {
     }
   }, [version, isTimerRunning, timeRemaining])
 
+  // Version B per-question timer effect
+  useEffect(() => {
+    if (version === 'Version B' && versionBTimerRunning && versionBTimeRemaining > 0 && !showFeedback) {
+      versionBTimerRef.current = setTimeout(() => {
+        setVersionBTimeRemaining(prev => {
+          if (prev <= 1) {
+            // Time's up for this question → auto-score 0 and show feedback
+            setVersionBTimerRunning(false)
+            if (!selectedAnswer) {
+              handleVersionBScore(0)
+            }
+            return 0
+          }
+          return prev - 1
+        })
+      }, 1000)
+    }
+    
+    return () => {
+      if (versionBTimerRef.current) {
+        clearTimeout(versionBTimerRef.current)
+        versionBTimerRef.current = null
+      }
+    }
+  }, [version, versionBTimerRunning, versionBTimeRemaining, showFeedback, selectedAnswer])
+
 
   useEffect(() => {
     const audio = audioRef.current
@@ -1930,6 +1968,13 @@ const Game = () => {
   const handleVersionBScore = (points: number) => {
     if (selectedAnswer) return // Already answered
     
+    // Stop Version B timer on scoring
+    if (versionBTimerRef.current) {
+      clearTimeout(versionBTimerRef.current)
+      versionBTimerRef.current = null
+    }
+    setVersionBTimerRunning(false)
+
     setSelectedAnswer('manual_score')
     
     let artistCorrect = false
@@ -2044,10 +2089,12 @@ const Game = () => {
         
         if (revealArtist) {
           const artistName = currentQuestion.song.artist
-          // Create display text: first letter + spaces preserved + underscores for other letters
+          // Create display text: first letter + last letter + spaces preserved + underscores for other letters
           const displayText = artistName.split('').map((char, index) => {
             if (index === 0) {
               return char.toUpperCase() // First letter revealed
+            } else if (index === artistName.length - 1) {
+              return char.toUpperCase() // Last letter revealed
             } else if (char === ' ') {
               return ' ' // Preserve spaces
             } else {
@@ -2062,10 +2109,12 @@ const Game = () => {
           console.log(`Revealing artist: ${displayText}`)
         } else {
           const songName = currentQuestion.song.title
-          // Create display text: first letter + spaces preserved + underscores for other letters
+          // Create display text: first letter + last letter + spaces preserved + underscores for other letters
           const displayText = songName.split('').map((char, index) => {
             if (index === 0) {
               return char.toUpperCase() // First letter revealed
+            } else if (index === songName.length - 1) {
+              return char.toUpperCase() // Last letter revealed
             } else if (char === ' ') {
               return ' ' // Preserve spaces
             } else {
@@ -2390,6 +2439,16 @@ const Game = () => {
     // Reset Version C timer and attempts
     setTimeRemaining(30)
     setIsTimerRunning(false)
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    if (versionBTimerRef.current) {
+      clearTimeout(versionBTimerRef.current)
+      versionBTimerRef.current = null
+    }
+    setVersionBTimeRemaining(20)
+    setVersionBTimerRunning(false)
     setAllAttemptedSongs([])
     // Reset Version C streak tracking
     setVersionCStreak(0)
@@ -2451,6 +2510,18 @@ const Game = () => {
   const backToPlaylist = () => {
     navigate('/')
   }
+
+  // Stop Version B timer whenever feedback is shown
+  useEffect(() => {
+    if (version !== 'Version B') return
+    if (showFeedback) {
+      if (versionBTimerRef.current) {
+        clearTimeout(versionBTimerRef.current)
+        versionBTimerRef.current = null
+      }
+      setVersionBTimerRunning(false)
+    }
+  }, [version, showFeedback])
 
   const formatTime = (time: number) => {
     const minutes = Math.floor(time / 60)
@@ -2855,7 +2926,25 @@ const Game = () => {
                   )}
                 </div>
               </div>
-            ) : (
+            ) : version === 'Version B' ? (
+              <div className="version-b-timer">
+                <div className="timer-display">
+                  <div className="timer-label">Time Remaining</div>
+                  <div className={`timer-value ${versionBTimeRemaining <= 10 ? 'timer-urgent' : ''}`}>
+                    {versionBTimeRemaining}s
+                  </div>
+                </div>
+              </div>
+          ) : version === 'Version B' ? (
+            <div className="version-b-timer">
+              <div className="timer-display">
+                <div className="timer-label">Time Remaining</div>
+                <div className={`timer-value ${versionBTimeRemaining <= 10 ? 'timer-urgent' : ''}`}>
+                  {versionBTimeRemaining}s
+                </div>
+              </div>
+            </div>
+          ) : (
               <div className="quiz-progress">
                 <span>Question {questionNumber} of {totalQuestions}</span>
               </div>

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1998,9 +1998,9 @@ const Game = () => {
 
     setSelectedAnswer('manual_score')
     
-    // Check for time bonus (answered within 7 seconds)
+    // Check for time bonus (answered within 5 seconds)
     const elapsedTime = Date.now() - questionStartTime
-    const hasTimeBonus = points > 0 && elapsedTime <= 7000
+    const hasTimeBonus = points > 0 && elapsedTime <= 5000
     let finalPoints = points
     
     if (hasTimeBonus) {
@@ -2966,8 +2966,8 @@ const Game = () => {
               <div className="version-b-timer">
                 <div className="timer-display">
                   <div className="timer-label">Time Remaining</div>
-                  <div className={`timer-value ${versionBTimeRemaining <= 10 ? 'timer-urgent' : ''}`}>
-                    {versionBTimeRemaining}s
+                  <div className={`timer-value ${versionBTimeRemaining >= 15 ? 'timer-bonus' : versionBTimeRemaining <= 5 ? 'timer-urgent' : ''}`}>
+                    {versionBTimeRemaining}
                   </div>
                 </div>
               </div>
@@ -2975,8 +2975,8 @@ const Game = () => {
             <div className="version-b-timer">
               <div className="timer-display">
                 <div className="timer-label">Time Remaining</div>
-                <div className={`timer-value ${versionBTimeRemaining <= 10 ? 'timer-urgent' : ''}`}>
-                  {versionBTimeRemaining}s
+                <div className={`timer-value ${versionBTimeRemaining >= 15 ? 'timer-bonus' : versionBTimeRemaining <= 5 ? 'timer-urgent' : ''}`}>
+                  {versionBTimeRemaining}
                 </div>
               </div>
             </div>

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -55,6 +55,10 @@ const Game = () => {
   const [opponentCorrect, setOpponentCorrect] = useState(false)
   const [opponentPointsEarned, setOpponentPointsEarned] = useState(0)
   const [gameComplete, setGameComplete] = useState(false)
+  
+  // Version B floating points animation
+  const [showFloatingPoints, setShowFloatingPoints] = useState(false)
+  const [floatingPointsValue, setFloatingPointsValue] = useState(0)
   const totalQuestions = 7
 
   // Version A specific state
@@ -1731,6 +1735,16 @@ const Game = () => {
     }
   }, [version, versionBTimerRunning, versionBTimeRemaining, showFeedback, selectedAnswer])
 
+  // Auto-hide floating points animation after delay
+  useEffect(() => {
+    if (showFloatingPoints) {
+      const timer = setTimeout(() => {
+        setShowFloatingPoints(false)
+      }, 2000) // Hide after 2 seconds
+      
+      return () => clearTimeout(timer)
+    }
+  }, [showFloatingPoints])
 
   useEffect(() => {
     const audio = audioRef.current
@@ -2013,6 +2027,9 @@ const Game = () => {
     
     if (points > 0) {
       playCorrectAnswerSfx()
+      // Trigger floating points animation
+      setFloatingPointsValue(points)
+      setShowFloatingPoints(true)
     }
     
     setShowFeedback(true)
@@ -3187,6 +3204,13 @@ const Game = () => {
                     Song #{getSongNumber(playlist || '2010s', currentQuestion.song.title, currentQuestion.song.artist)}
                   </div>
                 )}
+              </div>
+            )}
+            
+            {/* Version B Floating Points Animation */}
+            {version === 'Version B' && showFloatingPoints && (
+              <div className="floating-points">
+                +{floatingPointsValue}
               </div>
             )}
             


### PR DESCRIPTION
This PR refines the time bonus feature in Version B with improved visual feedback and tighter timing!

### ⏱️ Time Bonus Refinements

**Timing Updates:**
- **Time bonus window:** Reduced from 7 to 5 seconds
- Players must answer within **first 5 seconds** to earn double points
- More challenging and rewarding for quick responses

### 🎨 Timer Visual Improvements

**Color-Coded Timer States:**
1. **20-15 seconds:** 🟢 Bright green (Time Bonus window)
2. **14-6 seconds:** ⚪ Normal teal (Standard gameplay)
3. **5-0 seconds:** 🔴 Urgent red (Final warning)

**Enhanced Urgency Indicators:**
- Red timer appears only during **last 5 seconds** (was 10)
- Timer **scales up 30%** during urgent state
- Combines scaling with pulsing animation for maximum visibility
- Impossible to miss when time is running out

**UI Polish:**
- Removed "s" suffix from timer ("20" instead of "20s")
- Cleaner, more modern appearance
- "Time Remaining" label provides context

### 🎮 User Experience
- Tighter 5-second window increases challenge
- Clear visual feedback for bonus opportunity
- Dramatic scaling effect creates urgency
- Balanced timer states (green/normal/red)