### PR TITLE
Add Dramatic Entrance Animation for Lifelines

### DIFF
--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -2568,6 +2568,48 @@
   }
 }
 
+/* Version B Lifeline Entrance Animation (First Question) */
+.boosters-section.lifeline-entrance {
+  animation: lifelineEntrance 1.5s ease-out forwards;
+}
+
+.boosters-section.lifeline-entrance .booster-icon {
+  animation: lifelineIconEntrance 1.5s ease-out forwards;
+}
+
+@keyframes lifelineEntrance {
+  0% {
+    opacity: 0;
+    transform: translateY(-50px) scale(0.8);
+  }
+  50% {
+    opacity: 1;
+    transform: translateY(-10px) scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes lifelineIconEntrance {
+  0% {
+    opacity: 0;
+    transform: scale(0.5) rotateY(180deg);
+    box-shadow: 0 0 0 rgba(78, 205, 196, 0);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(1.2) rotateY(0deg);
+    box-shadow: 0 0 40px rgba(78, 205, 196, 1), 0 0 80px rgba(78, 205, 196, 0.8), 0 0 120px rgba(78, 205, 196, 0.6);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) rotateY(0deg);
+    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
+  }
+}
+
 /* Version B Special Question Playlist Display */
 .special-playlist-display {
   position: fixed;

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -140,6 +140,9 @@ const Game = () => {
   // Version B Lifeline attention animation
   const [showLifelineAttention, setShowLifelineAttention] = useState(false)
   const lifelineAttentionTimerRef = useRef<NodeJS.Timeout | null>(null)
+  
+  // Version B Lifeline entrance animation (for first question)
+  const [showLifelineEntrance, setShowLifelineEntrance] = useState(false)
   // 2010s playlist songs with curated alternatives
   const songs2010s: Song[] = [
     { 
@@ -1386,6 +1389,15 @@ const Game = () => {
       setVersionBTimerRunning(true)
       // Track question start time for time bonus
       setQuestionStartTime(Date.now())
+      
+      // Trigger lifeline entrance animation on first question
+      if (questionNumber === 1) {
+        setShowLifelineEntrance(true)
+        // Remove animation class after animation completes
+        setTimeout(() => {
+          setShowLifelineEntrance(false)
+        }, 1500) // Match animation duration
+      }
     } else if (version === 'Version C') {
       // Version C: Start timer if not already running, or continue if still running
       if (!isTimerRunning && timeRemaining === 30) {
@@ -3213,7 +3225,7 @@ const Game = () => {
 
             {/* Version B Boosters */}
             {version === 'Version B' && !showFeedback && (
-              <div className={`boosters-section ${showLifelineAttention ? 'lifeline-attention' : ''}`}>
+              <div className={`boosters-section ${showLifelineAttention ? 'lifeline-attention' : ''} ${showLifelineEntrance ? 'lifeline-entrance' : ''}`}>
                 <div className="boosters-header">LIFELINES</div>
                 <div className="boosters-container">
                   {availableLifelines.includes('skip') && (


### PR DESCRIPTION
## Changes

### Lifeline Entrance Animation
- Added dramatic entrance animation that plays **only on Question 1** when starting a new Version B session
- Helps players understand they are receiving randomly selected lifelines
- Animation lasts 1.5 seconds and automatically clears

### Animation Effects

**Lifeline Section Animation:**
- Fades in from 0 to full opacity
- Slides down from -50px with a bounce effect
- Scales from 0.8 → 1.1 → 1.0 for dynamic feel

**Individual Icon Animation:**
- Each icon performs a 3D flip (180° rotateY)
- Scales from 0.5 → 1.2 → 1.0
- Dramatic teal glow effect that peaks at 60%
- Creates a "cards being dealt" visual metaphor

### Implementation Details
- Added `showLifelineEntrance` state to control animation
- Triggers only when `questionNumber === 1` in Version B
- Uses CSS keyframe animations for smooth, performant effects
- Animation class automatically removed after completion

### User Experience Benefits
- **Visual Communication:** Clearly shows players which 3 lifelines they received
- **Engagement:** Dramatic entrance draws attention and adds excitement
- **Understanding:** Reinforces that lifelines are randomly selected each session
- **Polish:** Premium feel that enhances overall game quality

### Technical Notes
- No performance impact (CSS animations, runs once per session)
- Works seamlessly with existing lifeline attention animation
- Respects all existing lifeline functionality