### PR TITLE
feat(version-c): enhance rapid-fire mode gameplay and UI

### DIFF
--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -160,6 +160,13 @@
   min-width: 500px;
 }
 
+/* Version C audio controls positioning */
+.version-c .audio-controls {
+  top: 35%;
+  padding: 1.5rem 2rem;
+  gap: 1rem;
+}
+
 .album-art-display {
   position: fixed;
   top: 40%;
@@ -228,6 +235,20 @@
   min-width: 400px;
 }
 
+/* Version C progress bar positioning */
+.version-c .progress-bar {
+  position: fixed;
+  top: 34%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 80;
+  padding: 20px 30px;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(10px);
+  border-radius: 15px;
+  border: 2px solid rgba(255, 255, 255, 0.1);
+}
+
 .progress-time {
   display: flex;
   justify-content: space-between;
@@ -248,6 +269,24 @@
   background: linear-gradient(90deg, #4ecdc4, #44a08d);
   border-radius: 3px;
   transition: width 0.1s ease;
+}
+
+/* Version C enhanced progress bar */
+.version-c .progress-track {
+  height: 8px;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+}
+
+.version-c .progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #4ecdc4, #44a08d);
+  box-shadow: 0 0 10px rgba(78, 205, 196, 0.5);
+}
+
+.version-c .progress-time {
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 600;
 }
 
 .control-buttons {
@@ -342,12 +381,12 @@
 }
 
 .player-container {
-  bottom: calc(15% + 150px);
+  bottom: calc(30% + 150px);
   left: calc(8% + 30px);
 }
 
 .opponent-container {
-  bottom: calc(15% + 150px);
+  bottom: calc(30% + 150px);
   right: calc(8% + 30px);
 }
 
@@ -1132,12 +1171,12 @@
   }
   
   .player-container {
-    bottom: calc(12% + 150px);
+    bottom: calc(27% + 150px);
     left: calc(5% + 30px);
   }
   
   .opponent-container {
-    bottom: calc(12% + 150px);
+    bottom: calc(27% + 150px);
     right: calc(5% + 30px);
   }
   
@@ -1414,6 +1453,7 @@
   min-height: 55px; /* Reserve space to prevent layout shift */
 }
 
+
 .sound-bars {
   display: flex;
   align-items: end;
@@ -1509,6 +1549,17 @@
   align-items: center;
   justify-content: center;
   margin-top: 0.5rem;
+}
+
+/* Version C control buttons positioning */
+.version-c .control-buttons {
+  position: fixed;
+  top: 48%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 85;
+  margin-top: 0;
+  padding: 20px 0;
 }
 
 /* Debug Section - Temporary for Speech Recognition Testing */
@@ -3105,14 +3156,27 @@
 
 /* Version C Rapid-Fire Timer and UI Styles */
 .version-c-timer {
+  position: fixed;
+  top: 18%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 15px;
+  z-index: 100;
+  pointer-events: none;
+  padding: 10px 0;
 }
 
 .timer-display {
   text-align: center;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(10px);
+  padding: 30px 50px;
+  border-radius: 20px;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
 }
 
 .timer-label {
@@ -3141,6 +3205,7 @@
 .timer-value.timer-urgent {
   background: linear-gradient(135deg, #ff6b6b, #ee5a24);
   -webkit-background-clip: text;
+  background-clip: text;
   -webkit-text-fill-color: transparent;
   animation: urgentPulse 1s ease-in-out infinite;
 }
@@ -3607,11 +3672,23 @@
 .version-c-scoring {
   border: 3px solid rgba(76, 205, 196, 0.4);
   background: rgba(76, 205, 196, 0.05);
+  position: fixed;
+  top: 68%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 90;
+  padding: 25px 35px;
+  border-radius: 20px;
+  backdrop-filter: blur(10px);
+  max-width: 600px;
+  width: 90%;
+  margin-top: 20px;
 }
 
 .rapid-fire-header {
   text-align: center;
-  margin-bottom: 20px;
+  margin-bottom: 15px;
+  padding-bottom: 10px;
 }
 
 .rapid-fire-title {
@@ -3626,6 +3703,83 @@
   font-size: 14px;
   color: rgba(255, 255, 255, 0.8);
   font-style: italic;
+}
+
+/* Version C specific button spacing */
+.version-c-scoring .score-buttons {
+  gap: 1.2rem;
+  margin-bottom: 0.8rem;
+  padding-top: 10px;
+}
+
+/* Version C Answer Feedback */
+.version-c-answer-feedback {
+  position: fixed;
+  top: 68%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 95;
+  background: rgba(78, 205, 196, 0.15);
+  backdrop-filter: blur(15px);
+  border: 3px solid rgba(78, 205, 196, 0.5);
+  border-radius: 20px;
+  padding: 30px 40px;
+  max-width: 600px;
+  width: 90%;
+  animation: feedbackSlideIn 0.3s ease-out;
+}
+
+.answer-feedback-title {
+  text-align: center;
+  font-size: 18px;
+  font-weight: 700;
+  color: #4ecdc4;
+  margin-bottom: 20px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  text-shadow: 0 2px 8px rgba(78, 205, 196, 0.4);
+}
+
+.answer-feedback-content {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.answer-feedback-item {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.answer-feedback-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.answer-feedback-value {
+  font-size: 18px;
+  font-weight: 700;
+  color: #ffffff;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+@keyframes feedbackSlideIn {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
 }
 
 /* Version C Final Results Styles */
@@ -3810,7 +3964,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  bottom: calc(15% + 150px);
+  bottom: calc(30% + 150px);
   right: calc(8% - 50px);
   z-index: 10;
 }
@@ -4034,6 +4188,15 @@
 
 /* Mobile adjustments for Version C */
 @media (max-width: 768px) {
+  .version-c-timer {
+    width: 90%;
+    max-width: 400px;
+  }
+  
+  .timer-display {
+    padding: 20px 30px;
+  }
+  
   .timer-value {
     font-size: 36px;
     min-width: 100px;
@@ -4162,7 +4325,7 @@
   /* Mobile adjustments for score tracker */
   .score-tracker-container {
     position: absolute;
-    bottom: calc(12% + 150px);
+    bottom: calc(27% + 150px);
     right: calc(5% - 30px);
     z-index: 10;
   }

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -68,7 +68,7 @@ const Game = () => {
   const [speedBonusToggle, setSpeedBonusToggle] = useState(false)
   
   // Version C specific state
-  const [timeRemaining, setTimeRemaining] = useState(30)
+  const [timeRemaining, setTimeRemaining] = useState(60)
   const [isTimerRunning, setIsTimerRunning] = useState(false)
   const [allAttemptedSongs, setAllAttemptedSongs] = useState<Array<{
     song: any,
@@ -84,6 +84,7 @@ const Game = () => {
   const [timerPulse, setTimerPulse] = useState(false)
   const [versionCStreak, setVersionCStreak] = useState(0) // Track streak for progressive multipliers
   const [showScoreConfetti, setShowScoreConfetti] = useState(false) // Track confetti animation
+  const [showVersionCFeedback, setShowVersionCFeedback] = useState(false) // Track answer feedback display
   
   const timerRef = useRef<NodeJS.Timeout | null>(null)
   
@@ -1356,7 +1357,7 @@ const Game = () => {
       // Version B has no opponent mechanics
     } else if (version === 'Version C') {
       // Version C: Start timer if not already running, or continue if still running
-      if (!isTimerRunning && timeRemaining === 30) {
+      if (!isTimerRunning && timeRemaining === 60) {
         setIsTimerRunning(true)
       } else if (!isTimerRunning && timeRemaining > 0) {
         setIsTimerRunning(true)
@@ -1653,7 +1654,7 @@ const Game = () => {
     // Version C: Start timer when game begins
     if (version === 'Version C') {
       setIsTimerRunning(true)
-      setTimeRemaining(30)
+      setTimeRemaining(60)
       setAllAttemptedSongs([])
     }
     
@@ -1870,13 +1871,13 @@ const Game = () => {
       }, 3000) // Clear notification after 3 seconds
     }
     
-    // Give +3 bonus seconds for any points earned
+    // Give +5 bonus seconds for any points earned
     if (points > 0 && isTimerRunning) {
-      console.log('🎵 VERSION C: Adding +3 bonus seconds for scoring points!')
-      setTimeRemaining(prev => prev + 3)
+      console.log('🎵 VERSION C: Adding +5 bonus seconds for scoring points!')
+      setTimeRemaining(prev => prev + 5)
       
       // Show visual notification for bonus time
-      setAutoBoosterNotification('⏰ +3 Bonus Seconds!')
+      setAutoBoosterNotification('⏰ +5 Bonus Seconds!')
       setTimeout(() => {
         setAutoBoosterNotification(null)
       }, 2000) // Clear notification after 2 seconds
@@ -1887,7 +1888,7 @@ const Game = () => {
         setTimerPulse(false)
       }, 1000) // Remove pulse after 1 second
       
-      console.log('⏰ BONUS TIME: +3 seconds awarded for scoring!')
+      console.log('⏰ BONUS TIME: +5 seconds awarded for scoring!')
     }
     
     if (points > 0) {
@@ -1915,15 +1916,18 @@ const Game = () => {
       audio.oncanplaythrough = null
     }
     
-    // Reset selected answer for next question
-    setSelectedAnswer(null)
+    // Show feedback with correct answer
+    setShowVersionCFeedback(true)
     
-    // For Version C, immediately move to next song (very short delay to allow state updates)
+    // Hide feedback and move to next question after a brief display
     setTimeout(() => {
+      setShowVersionCFeedback(false)
+      setSelectedAnswer(null)
+      
       console.log('🎵 VERSION C: Moving to next question after scoring', points, 'points')
       console.log('🎵 VERSION C: Current timer running:', isTimerRunning, 'Time remaining:', timeRemaining)
       startNewQuestion()
-    }, 200) // Reduced delay for faster progression
+    }, 2000) // Show feedback for 2 seconds
   }
 
   // Version B manual scoring function
@@ -2388,7 +2392,7 @@ const Game = () => {
     setQuestionsCorrectness([])
     setOpponentQuestionsCorrectness([])
     // Reset Version C timer and attempts
-    setTimeRemaining(30)
+    setTimeRemaining(60)
     setIsTimerRunning(false)
     setAllAttemptedSongs([])
     // Reset Version C streak tracking
@@ -2628,10 +2632,6 @@ const Game = () => {
                       <div className="stat-item">
                         <div className="stat-value">{allAttemptedSongs.filter(song => song.pointsEarned > 0).length}</div>
                         <div className="stat-label">Songs Scored</div>
-                      </div>
-                      <div className="stat-item">
-                        <div className="stat-value">{allAttemptedSongs.length > 0 ? Math.round((score / (allAttemptedSongs.length * 20)) * 100) : 0}%</div>
-                        <div className="stat-label">Accuracy</div>
                       </div>
                     </div>
                   </div>
@@ -3000,7 +3000,7 @@ const Game = () => {
             )}
 
 
-            {!showFeedback && (
+            {!showFeedback && !showVersionCFeedback && (
               <div className="progress-bar">
                 <div className="progress-time">
                   <span>{formatTime(currentTime)}</span>
@@ -3015,7 +3015,7 @@ const Game = () => {
               </div>
             )}
 
-            {!showFeedback && (
+            {!showFeedback && !showVersionCFeedback && (
               <div className="control-buttons">
                 <button 
                   className={`control-btn play-pause-btn ${selectedAnswer ? 'disabled' : ''}`}
@@ -3106,7 +3106,7 @@ const Game = () => {
               console.log('🎯 VERSION C SCORING BUTTONS CHECK:', { version, isVersionC: version === 'Version C', selectedAnswer, showFeedback });
               return null;
             })()}
-            {version === 'Version C' && !selectedAnswer && !showFeedback && (
+            {version === 'Version C' && !selectedAnswer && !showFeedback && !showVersionCFeedback && (
               <div className="manual-scoring version-c-scoring">
                 <div className="rapid-fire-header">
                   <div className="rapid-fire-title">⚡ Rapid Fire Mode</div>
@@ -3117,7 +3117,7 @@ const Game = () => {
                     className="score-button score-0"
                     onClick={() => handleVersionCScore(0)}
                   >
-                    0 Points
+                    Skip
                   </button>
                   <button
                     className="score-button score-10"
@@ -3137,6 +3137,23 @@ const Game = () => {
                     Song #{getSongNumber(playlist || '2010s', currentQuestion.song.title, currentQuestion.song.artist)}
                   </div>
                 )}
+              </div>
+            )}
+            
+            {/* Version C Answer Feedback */}
+            {version === 'Version C' && showVersionCFeedback && currentQuestion && (
+              <div className="version-c-answer-feedback">
+                <div className="answer-feedback-title">Correct Answer:</div>
+                <div className="answer-feedback-content">
+                  <div className="answer-feedback-item">
+                    <span className="answer-feedback-label">Artist:</span>
+                    <span className="answer-feedback-value">{currentQuestion.song.artist}</span>
+                  </div>
+                  <div className="answer-feedback-item">
+                    <span className="answer-feedback-label">Song:</span>
+                    <span className="answer-feedback-value">{currentQuestion.song.title}</span>
+                  </div>
+                </div>
               </div>
             )}
             


### PR DESCRIPTION
## Changes
- Increase timer duration from 30s to 60s for better pacing
- Increase bonus time reward from +3s to +5s per correct answer
- Add answer feedback display showing correct artist and song
- Improve UI positioning for timer, controls, and progress bar
- Enhance visual styling with better backdrop effects and borders
- Adjust player/opponent avatar positioning
- Remove accuracy stat from final results
- Show feedback for 2s before moving to next question

## Testing
- Tested Version C rapid-fire mode locally
- Verified timer mechanics and bonus time rewards
- Confirmed answer feedback displays correctly

## Type of Change
- [x] Feature enhancement
- [x] UI/UX improvement
- [ ] Bug fix
- [ ] Breaking change