### PR TITLE
feat: Improve Song Trivia results screen and replace boring questions

### DIFF
--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -1338,6 +1338,31 @@
   color: #ffffff;
 }
 
+/* Version B Song Trivia Results Styles */
+.trivia-question-text {
+  font-size: 1.3rem !important;
+  font-weight: 600 !important;
+  color: rgba(255, 255, 255, 0.95) !important;
+  margin-bottom: 1rem !important;
+  background: rgba(78, 205, 196, 0.1) !important;
+  border-left: 4px solid rgba(78, 205, 196, 0.6) !important;
+  padding: 1rem !important;
+}
+
+.trivia-correct-answer {
+  font-size: 1.2rem !important;
+  font-weight: 600 !important;
+  color: #ffffff !important;
+  background: rgba(78, 205, 196, 0.15) !important;
+  padding: 1rem !important;
+  border-radius: 8px !important;
+}
+
+.trivia-correct-answer strong {
+  color: #4ecdc4 !important;
+  font-size: 1.25rem !important;
+}
+
 /* Feedback Container Styles */
 .feedback-container {
   position: fixed;

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -141,6 +141,7 @@ const Game = () => {
   const [specialQuestionTypes, setSpecialQuestionTypes] = useState<{[key: number]: 'time-warp' | 'slo-mo' | 'hyperspeed' | 'song-trivia'}>({})
   const [specialQuestionPlaylist, setSpecialQuestionPlaylist] = useState<string | null>(null)
   const [specialQuestionType, setSpecialQuestionType] = useState<'time-warp' | 'slo-mo' | 'hyperspeed' | 'song-trivia' | null>(null)
+  const [usedTriviaSongIds, setUsedTriviaSongIds] = useState<string[]>([])
   
   // Version B Lifeline attention animation
   const [showLifelineAttention, setShowLifelineAttention] = useState(false)
@@ -157,9 +158,9 @@ const Game = () => {
       file: '/songs/2010s/AllofMeJohnLegend.mp3', 
       albumArt: '/assets/album-art/2010s/AllOfMeJohnLegend.jpeg',
       alternatives: ['When I Was Your Man - Bruno Mars', 'Stay With Me - Sam Smith', 'Thinking Out Loud - Ed Sheeran'],
-      triviaQuestion: 'What year was "All of Me" by John Legend released?',
-      triviaOptions: ['2011', '2012', '2013', '2014'],
-      triviaCorrectAnswer: '2013'
+      triviaQuestion: 'John Legend wrote "All of Me" about which famous model and TV personality?',
+      triviaOptions: ['Chrissy Teigen', 'Gigi Hadid', 'Heidi Klum', 'Tyra Banks'],
+      triviaCorrectAnswer: 'Chrissy Teigen'
     },
     { 
       id: '2', 
@@ -204,7 +205,10 @@ const Game = () => {
       artist: 'Travis Scott', 
       file: '/songs/2010s/GoosebumpsTravisScott.mp3', 
       albumArt: '/assets/album-art/2010s/GoosebumpsTravisScott.jpeg',
-      alternatives: ['Lucid Dreams - Juice WRLD', 'Life Goes On - Lil Baby feat. Gunna & Lil Uzi Vert', 'Psycho - Post Malone feat. Ty Dolla $ign']
+      alternatives: ['Lucid Dreams - Juice WRLD', 'Life Goes On - Lil Baby feat. Gunna & Lil Uzi Vert', 'Psycho - Post Malone feat. Ty Dolla $ign'],
+      triviaQuestion: 'Which rapper is featured on "Goosebumps" by Travis Scott?',
+      triviaOptions: ['Kendrick Lamar', 'Drake', 'Quavo', 'Offset'],
+      triviaCorrectAnswer: 'Kendrick Lamar'
     },
     { 
       id: '7', 
@@ -240,10 +244,7 @@ const Game = () => {
       artist: 'Lady Gaga', 
       file: '/songs/2010s/JustDanceLadyGaga.mp3', 
       albumArt: '/assets/album-art/2010s/JustDanceLadyGaga.jpeg',
-      alternatives: ['Poker Face - Lady Gaga', 'Bad Romance - Lady Gaga', 'Paparazzi - Lady Gaga'],
-      triviaQuestion: '"Just Dance" was Lady Gaga\'s debut single. What year was it released?',
-      triviaOptions: ['2007', '2008', '2009', '2010'],
-      triviaCorrectAnswer: '2008'
+      alternatives: ['Poker Face - Lady Gaga', 'Bad Romance - Lady Gaga', 'Paparazzi - Lady Gaga']
     },
     { 
       id: '11', 
@@ -327,7 +328,10 @@ const Game = () => {
       artist: 'Walk the Moon', 
       file: '/songs/2010s/ShupUpAndDance.mp3', 
       albumArt: '/assets/album-art/2010s/ShutUpAndDance.jpeg',
-      alternatives: ['Fireflies - Owl City', 'Safe and Sound - Capital Cities', 'Cool Kids - Echosmith']
+      alternatives: ['Fireflies - Owl City', 'Safe and Sound - Capital Cities', 'Cool Kids - Echosmith'],
+      triviaQuestion: 'What city is the band Walk the Moon originally from?',
+      triviaOptions: ['Nashville', 'Cincinnati', 'Portland', 'Austin'],
+      triviaCorrectAnswer: 'Cincinnati'
     },
     { 
       id: '21', 
@@ -396,7 +400,10 @@ const Game = () => {
       artist: 'Ciara', 
       file: '/songs/2000s/1,2StepCiara.mp3', 
       albumArt: '/assets/album-art/2000s/1,2StepCiara.jpeg',
-      alternatives: ['Goodies - Ciara feat. Petey Pablo', 'Oh - Ciara feat. Ludacris', 'Get Up - Ciara feat. Chamillionaire']
+      alternatives: ['Goodies - Ciara feat. Petey Pablo', 'Oh - Ciara feat. Ludacris', 'Get Up - Ciara feat. Chamillionaire'],
+      triviaQuestion: 'Which rapper is featured on "1,2 Step" by Ciara?',
+      triviaOptions: ['Ludacris', 'Missy Elliott', 'Lil Jon', 'T.I.'],
+      triviaCorrectAnswer: 'Missy Elliott'
     },
     { 
       id: '2', 
@@ -412,10 +419,7 @@ const Game = () => {
       artist: 'Avril Lavigne', 
       file: '/songs/2000s/ComplicatedAvrilLavigne.mp3', 
       albumArt: '/assets/album-art/2000s/ComplicatedAvrilLavigne.jpeg',
-      alternatives: ['Sk8er Boi - Avril Lavigne', 'My Happy Ending - Avril Lavigne', 'I\'m with You - Avril Lavigne'],
-      triviaQuestion: 'What year was Avril Lavigne\'s "Complicated" released?',
-      triviaOptions: ['2001', '2002', '2003', '2004'],
-      triviaCorrectAnswer: '2002'
+      alternatives: ['Sk8er Boi - Avril Lavigne', 'My Happy Ending - Avril Lavigne', 'I\'m with You - Avril Lavigne']
     },
     { 
       id: '4', 
@@ -431,7 +435,10 @@ const Game = () => {
       artist: 'Train', 
       file: '/songs/2000s/DropsOfJupiterTrain.mp3', 
       albumArt: '/assets/album-art/2000s/DropsOfJupiterTrain.jpeg',
-      alternatives: ['Hey Soul Sister - Train', 'Drive By - Train', 'Meet Virginia - Train']
+      alternatives: ['Hey Soul Sister - Train', 'Drive By - Train', 'Meet Virginia - Train'],
+      triviaQuestion: '"Drops of Jupiter" won a Grammy Award for which category?',
+      triviaOptions: ['Song of the Year', 'Best Rock Song', 'Record of the Year', 'Best Pop Performance'],
+      triviaCorrectAnswer: 'Best Rock Song'
     },
     { 
       id: '6', 
@@ -450,7 +457,10 @@ const Game = () => {
       artist: 'Owl City', 
       file: '/songs/2000s/FirefliesOwlCity.mp3', 
       albumArt: '/assets/album-art/2000s/FirefliesOwlCity.jpeg',
-      alternatives: ['Vanilla Twilight - Owl City', 'Hello Seattle - Owl City', 'The Saltwater Room - Owl City']
+      alternatives: ['Vanilla Twilight - Owl City', 'Hello Seattle - Owl City', 'The Saltwater Room - Owl City'],
+      triviaQuestion: 'Owl City is primarily the solo project of which artist?',
+      triviaOptions: ['Adam Young', 'Tyler Joseph', 'Brendon Urie', 'Patrick Stump'],
+      triviaCorrectAnswer: 'Adam Young'
     },
     { 
       id: '8', 
@@ -485,10 +495,7 @@ const Game = () => {
       artist: 'Backstreet Boys', 
       file: '/songs/2000s/IWantItThatWayBackstreetBoys.mp3', 
       albumArt: '/assets/album-art/2000s/IWantItThatWayBackstreetBoys.jpeg',
-      alternatives: ['Everybody - Backstreet Boys', 'As Long As You Love Me - Backstreet Boys', 'Quit Playing Games - Backstreet Boys'],
-      triviaQuestion: 'What year was "I Want It That Way" released?',
-      triviaOptions: ['1997', '1998', '1999', '2000'],
-      triviaCorrectAnswer: '1999'
+      alternatives: ['Everybody - Backstreet Boys', 'As Long As You Love Me - Backstreet Boys', 'Quit Playing Games - Backstreet Boys']
     },
     { 
       id: '12', 
@@ -674,10 +681,7 @@ const Game = () => {
       artist: 'Miley Cyrus', 
       file: '/songs/2020s/FlowersMileyCyrus.mp3', 
       albumArt: '/assets/album-art/2020s/FlowersMileyCyrus.jpeg',
-      alternatives: ['Party in the U.S.A. - Miley Cyrus', 'Wrecking Ball - Miley Cyrus', 'The Climb - Miley Cyrus'],
-      triviaQuestion: 'What year was "Flowers" by Miley Cyrus released?',
-      triviaOptions: ['2021', '2022', '2023', '2024'],
-      triviaCorrectAnswer: '2023'
+      alternatives: ['Party in the U.S.A. - Miley Cyrus', 'Wrecking Ball - Miley Cyrus', 'The Climb - Miley Cyrus']
     },
     { 
       id: '6', 
@@ -686,7 +690,10 @@ const Game = () => {
       file: '/songs/2020s/GoodLuckBabeChappellRoan.mp3', 
       albumArt: '/assets/album-art/2020s/GoodLuckBabeChappellRoan.jpeg',
       alternatives: ['Pink Pony Club - Chappell Roan', 'Red Wine Supernova - Chappell Roan', 'HOT TO GO! - Chappell Roan'],
-      artistAlternatives: ['Chapel Roan', 'Chapelle Roan', 'Chappel Roan']
+      artistAlternatives: ['Chapel Roan', 'Chapelle Roan', 'Chappel Roan'],
+      triviaQuestion: 'What is Chappell Roan\'s debut studio album called?',
+      triviaOptions: ['The Rise and Fall of a Midwest Princess', 'Pink Pony Club', 'Midwest Magic', 'Naked in Manhattan'],
+      triviaCorrectAnswer: 'The Rise and Fall of a Midwest Princess'
     },
     { 
       id: '7', 
@@ -714,7 +721,10 @@ const Game = () => {
       artist: 'Eminem', 
       file: '/songs/2020s/HoudiniEminem.mp3', 
       albumArt: '/assets/album-art/2020s/HoudiniEminem.jpeg',
-      alternatives: ['Lose Yourself - Eminem', 'Till I Collapse - Eminem', 'The Real Slim Shady - Eminem']
+      alternatives: ['Lose Yourself - Eminem', 'Till I Collapse - Eminem', 'The Real Slim Shady - Eminem'],
+      triviaQuestion: '"Houdini" samples which classic Eminem song?',
+      triviaOptions: ['My Name Is', 'Without Me', 'The Real Slim Shady', 'Just Lose It'],
+      triviaCorrectAnswer: 'Without Me'
     },
     { 
       id: '10', 
@@ -757,10 +767,7 @@ const Game = () => {
       artist: 'Justin Bieber', 
       file: '/songs/2020s/PeachesJustinBieber.mp3', 
       albumArt: '/assets/album-art/2020s/PeachesJustinBieber.jpeg',
-      alternatives: ['Sorry - Justin Bieber', 'Love Yourself - Justin Bieber', 'What Do You Mean? - Justin Bieber'],
-      triviaQuestion: 'What year was "Peaches" by Justin Bieber released?',
-      triviaOptions: ['2019', '2020', '2021', '2022'],
-      triviaCorrectAnswer: '2021'
+      alternatives: ['Sorry - Justin Bieber', 'Love Yourself - Justin Bieber', 'What Do You Mean? - Justin Bieber']
     },
     { 
       id: '15', 
@@ -884,7 +891,10 @@ const Game = () => {
       artist: 'TLC', 
       file: '/songs/90s/NoScrubsTLC.mp3', 
       albumArt: '/assets/album-art/90s/NoScrubsTLC.jpeg',
-      alternatives: ['Waterfalls - TLC', 'What\'s Up? - 4 Non Blondes', 'I Will Always Love You - Whitney Houston']
+      alternatives: ['Waterfalls - TLC', 'What\'s Up? - 4 Non Blondes', 'I Will Always Love You - Whitney Houston'],
+      triviaQuestion: 'How many members were in the R&B group TLC?',
+      triviaOptions: ['2', '3', '4', '5'],
+      triviaCorrectAnswer: '3'
     },
     { 
       id: '4', 
@@ -893,7 +903,10 @@ const Game = () => {
       file: '/songs/90s/CaliforniaLove2Pac.mp3', 
       albumArt: '/assets/album-art/90s/CaliforniaLove2Pac.jpeg',
       alternatives: ['Changes - 2Pac', 'Juicy - The Notorious B.I.G.', 'Gangsta\'s Paradise - Coolio'],
-      artistAlternatives: ['Tupac', '2-Pac', 'Tupac Shakur', 'Two Pac']
+      artistAlternatives: ['Tupac', '2-Pac', 'Tupac Shakur', 'Two Pac'],
+      triviaQuestion: 'Which legendary producer is featured on "California Love" with 2Pac?',
+      triviaOptions: ['Dr. Dre', 'Snoop Dogg', 'Ice Cube', 'Eminem'],
+      triviaCorrectAnswer: 'Dr. Dre'
     },
     { 
       id: '5', 
@@ -901,10 +914,7 @@ const Game = () => {
       artist: 'Spice Girls', 
       file: '/songs/90s/WannabeSpiceGirls.mp3', 
       albumArt: '/assets/album-art/90s/WannabeSpiceGirls.jpeg',
-      alternatives: ['Say You\'ll Be There - Spice Girls', 'MMMBop - Hanson', 'I Want It That Way - Backstreet Boys'],
-      triviaQuestion: 'What year was "Wannabe" by Spice Girls released?',
-      triviaOptions: ['1995', '1996', '1997', '1998'],
-      triviaCorrectAnswer: '1996'
+      alternatives: ['Say You\'ll Be There - Spice Girls', 'MMMBop - Hanson', 'I Want It That Way - Backstreet Boys']
     },
     { 
       id: '6', 
@@ -1279,22 +1289,58 @@ const Game = () => {
       
       const playlistSongs = getPlaylistSongs(currentPlaylist)
       
-      // Filter songs that have trivia questions
+      // Filter songs that have trivia questions AND haven't been used yet
       const songsWithTrivia = playlistSongs.filter(song => 
-        song.triviaQuestion && song.triviaOptions && song.triviaCorrectAnswer
+        song.triviaQuestion && song.triviaOptions && song.triviaCorrectAnswer &&
+        !usedTriviaSongIds.includes(song.id)
       )
       
+      console.log('🎯 SONG TRIVIA: Available unused trivia songs:', songsWithTrivia.length)
+      
       if (songsWithTrivia.length === 0) {
-        console.error('❌ No songs with trivia questions found in playlist', currentPlaylist)
-        // Fallback to regular question generation
-        return generateQuizQuestion()
+        console.error('❌ No unused trivia questions found in playlist', currentPlaylist)
+        // If all trivia questions have been used, reset and allow reuse
+        console.log('🔄 SONG TRIVIA: Resetting used trivia songs for this playlist')
+        setUsedTriviaSongIds([])
+        
+        // Get all songs with trivia (ignoring used status since we just reset)
+        const allSongsWithTrivia = playlistSongs.filter(song => 
+          song.triviaQuestion && song.triviaOptions && song.triviaCorrectAnswer
+        )
+        
+        if (allSongsWithTrivia.length === 0) {
+          console.error('❌ No songs with trivia questions found in playlist', currentPlaylist)
+          // Fallback to regular question generation
+          return generateQuizQuestion()
+        }
+        
+        // Select from reset pool
+        const randomIndex = Math.floor(Math.random() * allSongsWithTrivia.length)
+        const triviaSong = allSongsWithTrivia[randomIndex] as Song
+        
+        // Mark as used
+        setUsedTriviaSongIds([triviaSong.id])
+        
+        console.log('🎯 SONG TRIVIA: Selected song (after reset)', triviaSong.title, 'by', triviaSong.artist)
+        
+        return {
+          song: triviaSong,
+          options: triviaSong.triviaOptions!,
+          correctAnswer: triviaSong.triviaCorrectAnswer!,
+          isSongTrivia: true,
+          triviaQuestionText: triviaSong.triviaQuestion!
+        }
       }
       
-      // Select a random song with trivia
+      // Select a random song with trivia from unused ones
       const randomIndex = Math.floor(Math.random() * songsWithTrivia.length)
       const triviaSong = songsWithTrivia[randomIndex] as Song
       
+      // Mark this song as used
+      setUsedTriviaSongIds(prev => [...prev, triviaSong.id])
+      
       console.log('🎯 SONG TRIVIA: Selected song', triviaSong.title, 'by', triviaSong.artist)
+      console.log('🎯 SONG TRIVIA: Total used trivia songs:', usedTriviaSongIds.length + 1)
       
       return {
         song: triviaSong,
@@ -1767,6 +1813,7 @@ const Game = () => {
       setSpecialQuestionNumbers(selectedSpecialQuestions)
       setSpecialQuestionPlaylist(null) // Reset special playlist
       setSpecialQuestionType(null) // Reset special question type
+      setUsedTriviaSongIds([]) // Reset used trivia songs when starting new playlist
       
       // Pre-assign types to special questions to ensure variety
       const allTypes: ('time-warp' | 'slo-mo' | 'hyperspeed')[] = ['time-warp', 'slo-mo', 'hyperspeed']
@@ -2682,6 +2729,7 @@ const Game = () => {
     setSpecialQuestionTypes({}) // Reset special question types
     setSpecialQuestionPlaylist(null) // Reset special playlist
     setSpecialQuestionType(null) // Reset special question type
+    setUsedTriviaSongIds([]) // Reset used trivia songs tracking
     stopLifelineAttentionAnimation() // Stop lifeline attention animation
     setTimerPulse(false)
     setShowScoreConfetti(false)
@@ -3353,7 +3401,7 @@ const Game = () => {
             )}
 
             {/* Version B Boosters */}
-            {version === 'Version B' && !showFeedback && (
+            {version === 'Version B' && !showFeedback && !(currentQuestion && currentQuestion.isSongTrivia) && (
               <div className={`boosters-section ${showLifelineAttention ? 'lifeline-attention' : ''} ${showLifelineEntrance ? 'lifeline-entrance' : ''}`}>
                 <div className="boosters-header">LIFELINES</div>
                 <div className="boosters-container">
@@ -3618,19 +3666,32 @@ const Game = () => {
                   {version === 'Version B' && (
                     <div className="version-b-breakdown">
                       <div className="breakdown-details artist-title-section">
-                        {/* For 10 points with no specific correctness, don't show indicators */}
-                        {pointsEarned === 10 && !artistCorrect && !songCorrect ? (
+                        {/* Song Trivia: Show trivia question and correct answer */}
+                        {currentQuestion.isSongTrivia ? (
                           <>
-                            <p>Artist: {currentQuestion.song.artist}</p>
-                            <p>Song: {currentQuestion.song.title}</p>
+                            <p className="trivia-question-text">{currentQuestion.triviaQuestionText}</p>
+                            <p className="trivia-correct-answer">
+                              {pointsEarned > 0 ? '✅' : '❌'} Correct Answer: <strong>{currentQuestion.correctAnswer}</strong>
+                            </p>
+                            {pointsEarned > 0 && <p>Points Earned: {pointsEarned}</p>}
                           </>
                         ) : (
                           <>
-                            <p>{artistCorrect ? '✅' : '❌'} Artist: {currentQuestion.song.artist}</p>
-                            <p>{songCorrect ? '✅' : '❌'} Song: {currentQuestion.song.title}</p>
+                            {/* Regular questions: Show artist and song */}
+                            {pointsEarned === 10 && !artistCorrect && !songCorrect ? (
+                              <>
+                                <p>Artist: {currentQuestion.song.artist}</p>
+                                <p>Song: {currentQuestion.song.title}</p>
+                              </>
+                            ) : (
+                              <>
+                                <p>{artistCorrect ? '✅' : '❌'} Artist: {currentQuestion.song.artist}</p>
+                                <p>{songCorrect ? '✅' : '❌'} Song: {currentQuestion.song.title}</p>
+                              </>
+                            )}
+                            {pointsEarned > 0 && <p>Points Earned: {pointsEarned}</p>}
                           </>
                         )}
-                        {pointsEarned > 0 && <p>Points Earned: {pointsEarned}</p>}
                       </div>
                     </div>
                   )}


### PR DESCRIPTION
## 🎵 Song Trivia Improvements

### Results Screen Enhancement
- Display trivia question and correct answer on results screen instead of artist/song
- Add custom styling for trivia results with teal accents and highlighting

### Duplicate Question Prevention
- Implement tracking to prevent the same trivia question from appearing twice in the same Version B run
- Reset tracking on game restart and playlist change

### Better Trivia Questions
- ❌ Removed all 7 boring "release year" questions
- ✅ Added 20 new engaging trivia questions (5 per playlist)
  - Questions about artist collaborations, album names, and interesting music facts
  - Cover all playlists: 2010s, 2000s, 2020s, and 90s

### Files Changed
- `src/components/Game.tsx` - Logic for trivia tracking and results display
- `src/components/Game.css` - Styling for trivia results screen

**Changes:** 136 insertions(+), 50 deletions(-)