### PR TITLE
fix: Lifeline entrance animation now only plays once on first question

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -150,6 +150,7 @@ const Game = () => {
   
   // Version B Lifeline entrance animation (for first question)
   const [showLifelineEntrance, setShowLifelineEntrance] = useState(false)
+  const hasShownLifelineEntrance = useRef(false)
   // 2010s playlist songs with curated alternatives
   const songs2010s: Song[] = [
     { 
@@ -1535,9 +1536,10 @@ const Game = () => {
       // Track question start time for time bonus
       setQuestionStartTime(Date.now())
       
-      // Trigger lifeline entrance animation on first question
-      if (questionNumber === 1) {
+      // Trigger lifeline entrance animation on first question only (once per session)
+      if (questionNumber === 1 && !hasShownLifelineEntrance.current) {
         setShowLifelineEntrance(true)
+        hasShownLifelineEntrance.current = true
         // Remove animation class after animation completes
         setTimeout(() => {
           setShowLifelineEntrance(false)
@@ -1773,6 +1775,9 @@ const Game = () => {
         multipleChoiceArtist: false,
         multipleChoiceSong: false
       })
+      
+      // Reset lifeline entrance animation flag for new session
+      hasShownLifelineEntrance.current = false
       
       // Randomly select 1 or 2 special questions (50% chance for 2)
       const willHaveTwoSpecialQuestions = Math.random() < 0.5
@@ -2732,6 +2737,7 @@ const Game = () => {
     setSpecialQuestionType(null) // Reset special question type
     setUsedTriviaSongIds([]) // Reset used trivia songs tracking
     stopLifelineAttentionAnimation() // Stop lifeline attention animation
+    hasShownLifelineEntrance.current = false // Reset lifeline entrance animation flag
     setTimerPulse(false)
     setShowScoreConfetti(false)
     if (timerRef.current) {


### PR DESCRIPTION
## 🐛 Bug Fix

### Issue
The lifeline entrance animation was playing on both the **first and second questions** during a Version B run, instead of only playing on the first question.

### Root Cause
The condition `questionNumber === 1` was being evaluated multiple times (during special question transitions or other state updates), causing the animation to replay unintentionally.

### Solution
Implemented a tracking mechanism using `useRef` to ensure the animation only plays once per game session:

1. **Added tracking ref:** `hasShownLifelineEntrance`
2. **Updated condition:** Check both `questionNumber === 1` AND `!hasShownLifelineEntrance.current`
3. **Set flag after trigger:** Mark animation as shown
4. **Reset on new session:** Clear flag when starting new playlist/session
5. **Reset on restart:** Clear flag in `restartGame` function

### Behavior Now
✅ **First question of new game** → Animation plays
✅ **Second question** → Animation does NOT play
✅ **Restart game** → Animation plays again on first question
✅ **New playlist** → Animation plays again on first question

## 📝 Technical Details
- Used `useRef` instead of state to avoid triggering re-renders
- Reset flag in two locations: `restartGame()` and playlist initialization
- Prevents animation from replaying during state updates or transitions

**Files Changed:** `src/components/Game.tsx`
**Changes:** 8 insertions(+), 2 deletions(-)