### PR TITLE
Restore audio playback for Song Trivia questions

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1676,12 +1676,6 @@ const Game = () => {
     // Auto-play the song after audio element has loaded the new source
     // Use multiple attempts to ensure audio plays reliably
     const attemptAutoPlay = (attemptNumber = 1, maxAttempts = 3, currentSpecialType?: 'time-warp' | 'slo-mo' | 'hyperspeed' | 'song-trivia' | 'finish-the-lyric') => {
-      // Skip audio playback for Song Trivia questions
-      if (currentSpecialType === 'song-trivia' || question.isSongTrivia) {
-        console.log('🎯 SONG TRIVIA: Skipping audio playback - trivia question mode')
-        setIsLoadingQuestion(false)
-        return
-      }
       const audioElement = audioRef.current
       console.log(`🎵 GAME: Auto-play attempt ${attemptNumber}/${maxAttempts} for ${version}:`, {
         hasAudioElement: !!audioElement,


### PR DESCRIPTION
Restore background music during Song Trivia special questions.

**Changes:**
- Removed check that was skipping audio playback for Song Trivia
- Songs now play in the background during Song Trivia questions
- Maintains the same audio behavior as other question types