### PR TITLE
Fix audio continuing to play after back to playlist navigation

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -2899,6 +2899,28 @@ const Game = () => {
   }
 
   const backToPlaylist = () => {
+    // Stop and cleanup audio before navigating away
+    const audio = audioRef.current
+    if (audio) {
+      console.log('🎵 BACK TO PLAYLIST: Stopping and cleaning up audio')
+      audio.pause()
+      audio.currentTime = 0
+      audio.src = '' // Clear the audio source to fully stop playback
+      audio.load() // Reset the audio element
+      setIsPlaying(false)
+      setCurrentTime(0)
+    }
+    
+    // Clear any running timers
+    if (versionBTimerRef.current) {
+      clearTimeout(versionBTimerRef.current)
+      versionBTimerRef.current = null
+    }
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    
     navigate('/')
   }
 


### PR DESCRIPTION
Fixes a bug where audio would continue playing or restart on the title screen or in other versions after quickly navigating back to playlists during Version B gameplay.

**Bug Fixed:**
- Audio continuing to play after clicking "Back to Playlists" during a question
- Songs restarting on title screen or in other game versions

**Changes:**
- Add comprehensive audio cleanup in `backToPlaylist()` function
- Clear audio source (`audio.src = ''`) and reset audio element
- Clear all running timers before navigation
- Properly update audio state (isPlaying, currentTime)