### PR TITLE
Add debug controls box with prominent DEBUG label

### DIFF
--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -627,11 +627,42 @@
   box-shadow: 0 8px 25px rgba(0, 0, 0, 0.5);
 }
 
-/* Version B Restart button - Debug only */
-.restart-button {
+/* Version B Debug Controls Container */
+.debug-controls-container {
   position: fixed;
   bottom: 2rem;
   right: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  z-index: 20;
+  background: rgba(0, 0, 0, 0.85);
+  border: 3px solid rgba(255, 165, 0, 0.8);
+  border-radius: 12px;
+  padding: 0;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(10px);
+  overflow: hidden;
+}
+
+.debug-label {
+  background: rgba(255, 165, 0, 0.9);
+  border-bottom: 2px solid rgba(255, 165, 0, 1);
+  padding: 0.5rem 0;
+  color: #ffffff;
+  font-size: 1.4rem;
+  font-weight: 800;
+  text-align: center;
+  letter-spacing: 2px;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  margin: 0;
+  width: 100%;
+  flex-shrink: 0;
+}
+
+/* Version B Restart button - Debug only */
+.restart-button {
   background: rgba(255, 0, 0, 0.7);
   border: 2px solid rgba(255, 255, 255, 0.3);
   border-radius: 8px;
@@ -641,7 +672,8 @@
   transition: all 0.3s ease;
   font-size: 1rem;
   font-weight: 500;
-  z-index: 20;
+  margin: 0 1rem;
+  align-self: stretch;
 }
 
 .restart-button:hover {
@@ -653,13 +685,10 @@
 
 /* Version B Debug Special Question Buttons */
 .debug-special-buttons {
-  position: fixed;
-  bottom: 6rem;
-  right: 2rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  z-index: 20;
+  padding: 0 1rem 1rem 1rem;
 }
 
 .debug-special-button {
@@ -1198,16 +1227,22 @@
     font-size: 0.9rem;
   }
   
-  .restart-button {
+  .debug-controls-container {
     bottom: 1rem;
     right: 1rem;
+  }
+
+  .debug-label {
+    font-size: 0.75rem;
+    padding: 0.3rem 0.6rem;
+  }
+
+  .restart-button {
     padding: 0.7rem 1.2rem;
     font-size: 0.9rem;
   }
   
   .debug-special-buttons {
-    bottom: 5rem;
-    right: 1rem;
     gap: 0.4rem;
   }
   

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -4083,20 +4083,18 @@ const Game = () => {
           ← Back to Playlists
         </button>
 
-        {/* Version B Restart Button - Debug Only */}
+        {/* Version B Debug Controls - Debug Only */}
         {version === 'Version B' && !showSpecialQuestionTransition && (
-          <button 
-            className="restart-button"
-            onClick={restartGame}
-            title="Restart Version B Session (Debug)"
-          >
-            Restart
-          </button>
-        )}
-
-        {/* Version B Special Question Debug Buttons */}
-        {version === 'Version B' && !showSpecialQuestionTransition && (
-          <div className="debug-special-buttons">
+          <div className="debug-controls-container">
+            <div className="debug-label">DEBUG</div>
+            <button 
+              className="restart-button"
+              onClick={restartGame}
+              title="Restart Version B Session (Debug)"
+            >
+              Restart
+            </button>
+            <div className="debug-special-buttons">
             <button 
               className="debug-special-button time-warp-debug"
               onClick={() => handleDebugSpecialQuestion('time-warp')}
@@ -4132,6 +4130,7 @@ const Game = () => {
             >
               FTL
             </button>
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
Groups all Version B debug controls in a clearly labeled box to distinguish them from the core game experience.

**Changes:**
- Created container box for all debug controls (restart + special question buttons)
- Added large "DEBUG" header label spanning full width
- Dark semi-transparent background with orange border
- Centered layout for better visual organization
- All buttons organized vertically within the box
- Mobile responsive styling