### PR TITLE
Version B: 40s Timer and Special Question Timing Adjustments

### DIFF
--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -628,6 +628,47 @@
 }
 
 /* Version B Debug Controls Container */
+/* Debug Special Questions Display */
+.debug-special-questions-display {
+  position: fixed;
+  top: 2rem;
+  right: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 20;
+  background: rgba(0, 0, 0, 0.85);
+  border: 2px solid rgba(138, 43, 226, 0.8);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(10px);
+  font-size: 0.9rem;
+  max-width: 300px;
+}
+
+.debug-display-label {
+  color: rgba(138, 43, 226, 1);
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 0.25rem;
+}
+
+.debug-display-numbers {
+  color: rgba(255, 255, 255, 0.9);
+  font-family: 'Courier New', monospace;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.debug-display-numbers .current-special {
+  color: #00ff00;
+  font-weight: 700;
+  text-shadow: 0 0 8px rgba(0, 255, 0, 0.6);
+}
+
 .debug-controls-container {
   position: fixed;
   bottom: 2rem;
@@ -1227,6 +1268,22 @@
     font-size: 0.9rem;
   }
   
+  .debug-special-questions-display {
+    top: 1rem;
+    right: 1rem;
+    font-size: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    max-width: 200px;
+  }
+
+  .debug-display-label {
+    font-size: 0.7rem;
+  }
+
+  .debug-display-numbers {
+    font-size: 0.7rem;
+  }
+
   .debug-controls-container {
     bottom: 1rem;
     right: 1rem;

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -320,7 +320,7 @@ const Game = () => {
   const [isTimerRunning, setIsTimerRunning] = useState(false)
   
   // Version B per-question timer state
-  const [versionBTimeRemaining, setVersionBTimeRemaining] = useState(20)
+  const [versionBTimeRemaining, setVersionBTimeRemaining] = useState(40)
   const [versionBTimerRunning, setVersionBTimerRunning] = useState(false)
   const [allAttemptedSongs, setAllAttemptedSongs] = useState<Array<{
     song: any,
@@ -1810,7 +1810,7 @@ const Game = () => {
         clearTimeout(versionBTimerRef.current)
         versionBTimerRef.current = null
       }
-      setVersionBTimeRemaining(20)
+      setVersionBTimeRemaining(40)
       setVersionBTimerRunning(true)
       // Track question start time for time bonus
       setQuestionStartTime(Date.now())
@@ -2062,8 +2062,8 @@ const Game = () => {
       const willHaveTwoSpecialQuestions = Math.random() < 0.5
       const numSpecialQuestions = willHaveTwoSpecialQuestions ? 2 : 1
       
-      // Generate special question numbers (2-7, excluding Question 1)
-      const availableQuestions = [2, 3, 4, 5, 6, 7]
+      // Generate special question numbers (3-7, excluding Questions 1-2)
+      const availableQuestions = [3, 4, 5, 6, 7]
       const selectedSpecialQuestions: number[] = []
       
       for (let i = 0; i < numSpecialQuestions; i++) {
@@ -2125,8 +2125,8 @@ const Game = () => {
         console.log('🎯 VERSION B: Fallback - Special Question set to Question 7')
       }
       
-      // Verify all special question numbers are valid (2-7)
-      const invalidQuestions = selectedSpecialQuestions.filter(q => q < 2 || q > 7)
+      // Verify all special question numbers are valid (3-7)
+      const invalidQuestions = selectedSpecialQuestions.filter(q => q < 3 || q > 7)
       if (invalidQuestions.length > 0) {
         console.error('❌ ERROR: Invalid special question numbers:', invalidQuestions)
         // Fallback to single question 7 if there's an issue
@@ -3007,7 +3007,7 @@ const Game = () => {
       clearTimeout(versionBTimerRef.current)
       versionBTimerRef.current = null
     }
-    setVersionBTimeRemaining(20)
+    setVersionBTimeRemaining(40)
     setVersionBTimerRunning(false)
     setAllAttemptedSongs([])
     // Reset Version C streak tracking
@@ -3519,8 +3519,8 @@ const Game = () => {
                   <div className="timer-label">Time Remaining</div>
                   <div className="spectrometer-container">
                     <div 
-                      className={`spectrometer-bar ${versionBTimeRemaining >= 15 ? 'spectrometer-bonus' : versionBTimeRemaining <= 5 ? 'spectrometer-urgent' : 'spectrometer-normal'}`}
-                      style={{ width: `${(versionBTimeRemaining / 20) * 100}%` }}
+                      className={`spectrometer-bar ${versionBTimeRemaining >= 35 ? 'spectrometer-bonus' : versionBTimeRemaining <= 10 ? 'spectrometer-urgent' : 'spectrometer-normal'}`}
+                      style={{ width: `${(versionBTimeRemaining / 40) * 100}%` }}
                     ></div>
                   </div>
                 </div>
@@ -4307,6 +4307,22 @@ const Game = () => {
         >
           ← Back to Playlists
         </button>
+
+        {/* Version B Special Questions Debug Display - DISABLED */}
+        {/* {version === 'Version B' && specialQuestionNumbers.length > 0 && (
+          <div className="debug-special-questions-display">
+            <div className="debug-display-label">Special Questions:</div>
+            <div className="debug-display-numbers">
+              {specialQuestionNumbers.map((num, index) => (
+                <span key={num} className={num === questionNumber ? 'current-special' : ''}>
+                  Q{num}
+                  {specialQuestionTypes[num] && ` (${specialQuestionTypes[num]})`}
+                  {index < specialQuestionNumbers.length - 1 && ', '}
+                </span>
+              ))}
+            </div>
+          </div>
+        )} */}
 
         {/* Version B Debug Controls - Debug Only */}
         {version === 'Version B' && !showSpecialQuestionTransition && (


### PR DESCRIPTION
## Changes

- Changed Version B timer from 20 seconds to 40 seconds
- Updated urgent phase to last 10 seconds (red/enlarged)
- Kept bonus phase at first 5 seconds (green/2X points)
- Special questions now only appear from Q3 onwards (not Q2)
- Added debug display for special questions (currently disabled)

## Timer Breakdown
- **First 5 seconds (35-40s):** Green spectrometer = Time Bonus (2X points)
- **Middle 25 seconds (10-35s):** Teal spectrometer = Normal
- **Last 10 seconds (0-10s):** Red spectrometer (grows larger) = Urgent phase