### PR TITLE
Version B Timer Improvements

### DIFF
--- a/src/components/Game.css
+++ b/src/components/Game.css
@@ -4013,6 +4013,11 @@
   position: relative;
 }
 
+/* Fast refill animation when lifeline is used */
+.spectrometer-bar.spectrometer-refill {
+  transition: width 0.15s ease-out, background 0.3s ease;
+}
+
 .spectrometer-bar::after {
   content: '';
   position: absolute;


### PR DESCRIPTION
## Timer Animation Improvements
- Reduce delay between lifelines and timer from 1s to 0.5s (total intro: 3.5s)
- Add fast timer refill animation (0.15s) when using lifelines
- Add fast timer refill animation (0.15s) when starting new questions

## Time Bonus Mechanics
- Disable time bonus when lifelines are used
- Remove green bonus glow from timer after lifeline use
- Prevent 2x points even if answered within 5 seconds
- Reset time bonus eligibility on new questions

## Technical Changes
- Added `isTimerRefilling` state for fast refill animation class
- Added `lifelineUsedThisQuestion` flag to track lifeline usage
- Updated timer visual logic to conditionally show bonus state
- CSS: Added `.spectrometer-refill` class with 0.15s transition