### PR TITLE
Fix: Skip Lifeline Intro Bug on Q1

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -2713,8 +2713,13 @@ const Game = () => {
       setSongMultipleChoiceOptions(null)
       
       // Generate and start a new question immediately (preserve timer to keep +15s bonus)
+      // Increment question number to avoid replaying intro on Q1 skip
+      const nextQuestionNum = questionNumber + 1
+      console.log('🎵 SKIP: Moving from question', questionNumber, 'to', nextQuestionNum)
+      setQuestionNumber(nextQuestionNum)
+      
       setTimeout(() => {
-        startNewQuestion(true) // Pass true to preserve the timer
+        startNewQuestionWithNumber(nextQuestionNum, undefined, true) // Pass the new question number and preserve timer
       }, 100) // Small delay to ensure clean state reset
     } else if (lifelineType === 'artistLetterReveal') {
       console.log('Artist Letter Reveal booster activated!')


### PR DESCRIPTION
## Bug Fixed
When the Skip lifeline was used on question 1, the entire intro sequence (lifelines, timer, playback animations) would replay on the next question.

## Root Cause
The `startNewQuestion()` function was using the current `questionNumber` state (1) which triggered the intro animation check again.

## Solution
- Increment `questionNumber` before calling `startNewQuestionWithNumber()`
- Pass the new question number directly to avoid state timing issues
- Skip now properly transitions from Q1 to Q2 without intro animations
- Timer preservation still works correctly (adds 15 seconds and preserves it)

## Testing
- Using Skip on Q1 now smoothly transitions to Q2
- No intro animations replay
- Timer bonus (+15s) still applies correctly